### PR TITLE
Remove preview suffix from PowerShell 7

### DIFF
--- a/editor/VSCode/tasks.json
+++ b/editor/VSCode/tasks.json
@@ -5,7 +5,7 @@
     "windows": {
         "options": {
             "shell": {
-                "executable": "C:/Program Files/PowerShell/7-preview/pwsh.exe",
+                "executable": "C:/Program Files/PowerShell/7/pwsh.exe",
                 "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command" ]
             }
         }


### PR DESCRIPTION
Due to PowerShell 7 release, the '-preview' suffix has been removed from the folder name.